### PR TITLE
Cursor support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,33 @@ Once the new VS Code window opens with your selected folder, you can immediately
 
 ---
 
+## Build from source
+
+Requirements: Node.js 18+.
+
+```bash
+# 1. Install dev dependencies
+npm install
+
+# 2. Package into a .vsix (uses @vscode/vsce; --no-dependencies skips bundling node_modules)
+npx @vscode/vsce package --no-dependencies
+# → open-folder-in-new-vscode-<version>.vsix
+```
+
+Install the produced `.vsix` from the editor:
+
+```bash
+# VS Code
+code --install-extension open-folder-in-new-vscode-1.1.0.vsix
+
+# Cursor (or any VS Code-based editor)
+cursor --install-extension open-folder-in-new-vscode-1.1.0.vsix
+```
+
+Or via the editor UI: **Extensions** panel → **⋯** menu → **Install from VSIX...**. Restart the editor so the new context-menu entry appears.
+
+---
+
 ## Feedback & Contributions
 
 - [Report issues](https://github.com/rajratnamaitry/open-folder-in-new-vscode/issues)

--- a/extension.js
+++ b/extension.js
@@ -5,31 +5,15 @@ const vscode = require('vscode');
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
 const openVscodeFn = (uri, uris) => {
-	const folders = uris || [uri];
-	console.log('openVscodeFn called with folders:', folders);
-	if (!vscode.workspace.workspaceFolders || vscode.workspace.workspaceFolders.length === 0) {
-		vscode.window.showErrorMessage('No workspace folders are open.');
-		return;
-	}
-	if (!folders || folders[0] === undefined) {
-		vscode.window.showErrorMessage('No folder selected to open in new VS Code instance.');
+	const folders = (uris && uris.length > 0) ? uris : (uri ? [uri] : []);
+	if (folders.length === 0) {
+		vscode.window.showErrorMessage('No folder selected to open in a new window.');
 		return;
 	}
 	folders.forEach(folderUri => {
-		const folderPath = folderUri.fsPath;
-		const terminal = vscode.window.createTerminal({
-			name: 'New vscode',
-			cwd: folderPath,
-			shellPath: 'code',
-			shellArgs: ['-n', folderPath]
+		vscode.commands.executeCommand('vscode.openFolder', folderUri, {
+			forceNewWindow: true
 		});
-		vscode.window.showInformationMessage(`Opening folder in new vscode !...`);// Display a message in the terminal
-		terminal.hide();
-		terminal.sendText(`code .`);
-		setTimeout(function () {
-			terminal.dispose(); // Display a message box to the user
-			vscode.window.showInformationMessage(`Folder opened in a new vscode!`);
-		}, 7000);
 	});
 }
 /**


### PR DESCRIPTION
The previous implementation opened a hidden terminal with `shellPath: 'code'` and sent `code .` to it, then disposed the terminal after a 7-second timeout. This has a few problems:

- It depends on the `code` CLI being on PATH. In VS Code-derivative editors (Cursor, VSCodium, etc.) the CLI is named differently, so the command silently fails or — worse — opens VS Code instead of the host editor.
- The fixed 7-second `setTimeout` is racy and leaks a terminal if the CLI call takes longer.
- `shellPath` is meant for an interactive shell, not a one-shot launcher, so the terminal can render an error before being disposed.

Replace it with the standard
`vscode.commands.executeCommand('vscode.openFolder', uri, { forceNewWindow: true })`, which is the official API for opening a folder in a new window. It works in VS Code and every fork that exposes the standard extension API, with no external CLI dependency.

Also drop the `workspace.workspaceFolders` guard — the API works fine without an existing workspace, so the check was a false constraint.